### PR TITLE
Fix 'test sign -it'.

### DIFF
--- a/src/console/commands/test.ts
+++ b/src/console/commands/test.ts
@@ -419,7 +419,7 @@ export let cmdTestSign = cmdTest.createCommand("sign", {
         description: "Sets number of iterations. Default 1",
         set: function(v: string) {
             let res = +v;
-            if (!defs.isNull(res))
+            if (!defs.isNumber(res))
                 throw new TypeError("Parameter --it must be number");
             if (res <= 0)
                 throw new TypeError("Parameter --it must be more then 0");


### PR DESCRIPTION
Hopefully this PR will fix this odd behaviour...

```
> test sign -it 200 -a all

Error: Parameter --it must be number
```